### PR TITLE
fixes variadic method calls; fixes some error omissions for better output on errors

### DIFF
--- a/cmd/tracegen/model.go
+++ b/cmd/tracegen/model.go
@@ -251,9 +251,13 @@ func NewMethodInvocation(method *astgen.MethodConfig) *MethodInvocation {
 }
 
 func (m *MethodInvocation) Build() ast.Stmt {
-	paramSelectors := []ast.Expr{}
+	var paramSelectors []ast.Expr
+	var ellipsisPos token.Pos
 	for _, param := range m.method.MethodParams {
 		paramSelectors = append(paramSelectors, ast.NewIdent(param.Names[0].String()))
+		if p, ok := param.Type.(*ast.Ellipsis); ok {
+			ellipsisPos = p.Pos()
+		}
 	}
 
 	callExpr := &ast.CallExpr{
@@ -261,7 +265,8 @@ func (m *MethodInvocation) Build() ast.Stmt {
 			X:   m.receiver,
 			Sel: ast.NewIdent(m.method.MethodName),
 		},
-		Args: paramSelectors,
+		Args:     paramSelectors,
+		Ellipsis: ellipsisPos,
 	}
 
 	if m.method.HasResults() {

--- a/pkg/astgen/generator.go
+++ b/pkg/astgen/generator.go
@@ -54,15 +54,19 @@ func (g *Generator) ProcessInterface(d resolution.TypeDiscovery) error {
 		return errors.New(fmt.Sprintf("type '%s' in '%s' is not interface!", d.Spec.Name.String(), d.Location))
 	}
 	for field := range internal.EachFieldInFieldList(iFaceType.Methods) {
+		var err error
 		switch t := field.Type.(type) {
 		case *ast.FuncType:
-			g.processMethod(context, field.Names[0].String(), t)
+			err = g.processMethod(context, field.Names[0].String(), t)
 		case *ast.Ident:
-			g.processSubInterfaceIdent(context, t)
+			err = g.processSubInterfaceIdent(context, t)
 		case *ast.SelectorExpr:
-			g.processSubInterfaceSelector(context, t)
+			err = g.processSubInterfaceSelector(context, t)
 		default:
 			return errors.New("Unknown statement in interface declaration.")
+		}
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes variadic method calls by adding the elliptic. **WARN:** _not sure if the token.Pos is set correctly!_
Fixes a small part of the error handling for ease of use when something is wrong with the generation process.