### PR TITLE
Add usage text to commands

### DIFF
--- a/cmd/logen/main.go
+++ b/cmd/logen/main.go
@@ -7,6 +7,7 @@ import (
 	"go/ast"
 	"go/build"
 	"go/token"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -17,6 +18,23 @@ import (
 	"github.com/Bo0mer/gentools/pkg/resolution"
 	"github.com/Bo0mer/gentools/pkg/transformation"
 )
+
+func init() {
+	flag.Usage = func() {
+		var out io.Writer = os.Stdout
+
+		fmt.Fprintln(out, "A tool that generates logging wrappers for interfaces.")
+		fmt.Fprintf(out, "Usage: %s [-h] SOURCE_DIR INTERFACE_NAME\n", path.Base(os.Args[0]))
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  Arguments:")
+		fmt.Fprintln(out, "    SOURCE_DIR       Path to the file containing the interface")
+		fmt.Fprintln(out, "    INTERFACE_NAME   Name of the interface which will be wrapped")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  Options:")
+		fmt.Fprintln(out, "    -h               Print this text and exit")
+		fmt.Fprintln(out, "")
+	}
+}
 
 func parseArgs() (sourceDir, interfaceName string, err error) {
 	flag.Parse()

--- a/cmd/mongen/main.go
+++ b/cmd/mongen/main.go
@@ -33,6 +33,25 @@ type args struct {
 	monitoringProvider string
 }
 
+func init() {
+	flag.Usage = func() {
+		var out io.Writer = os.Stdout
+
+		fmt.Fprintln(out, "A tool that generates monitoring wrappers for interfaces.")
+		fmt.Fprintf(out, "Usage: %s [-h] SOURCE_DIR INTERFACE_NAME [PROVIDER]\n", path.Base(os.Args[0]))
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  Arguments:")
+		fmt.Fprintln(out, "    SOURCE_DIR       Path to the file containing the interface")
+		fmt.Fprintln(out, "    INTERFACE_NAME   Name of the interface which will be wrapped")
+		fmt.Fprintln(out, "    PROVIDER         Monitoring provider to be used for the generated code")
+		fmt.Fprintf(out, "                     Can be one of:  %s  %s\n", goKitProvider, opencensusProvider)
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  Options:")
+		fmt.Fprintln(out, "    -h               Print this text and exit")
+		fmt.Fprintln(out, "")
+	}
+}
+
 func isValidProvider(provider string) bool {
 	return provider == goKitProvider || provider == opencensusProvider
 }

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/build"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -15,6 +16,23 @@ import (
 	"github.com/Bo0mer/gentools/pkg/resolution"
 	"github.com/Bo0mer/gentools/pkg/transformation"
 )
+
+func init() {
+	flag.Usage = func() {
+		var out io.Writer = os.Stdout
+
+		fmt.Fprintln(out, "A tool that generates tracing wrappers for interfaces.")
+		fmt.Fprintf(out, "Usage: %s [-h] SOURCE_DIR INTERFACE_NAME\n", path.Base(os.Args[0]))
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  Arguments:")
+		fmt.Fprintln(out, "    SOURCE_DIR       Path to the file containing the interface")
+		fmt.Fprintln(out, "    INTERFACE_NAME   Name of the interface which will be wrapped")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "  Options:")
+		fmt.Fprintln(out, "    -h               Print this text and exit")
+		fmt.Fprintln(out, "")
+	}
+}
 
 func parseArgs() (sourceDir, interfaceName string, err error) {
 	flag.Parse()


### PR DESCRIPTION
This should help when using the tools for the first time.

Example output:

```
./tracegen -h
A tool that generates tracing wrappers for interfaces.
Usage: tracegen [-h] SOURCE_DIR INTERFACE_NAME

  Arguments:
    SOURCE_DIR       Path to the file containing the interface
    INTERFACE_NAME   Name of the interface which will be wrapped

  Options:
    -h               Print this text and exit

```